### PR TITLE
fix caller mode for receiver

### DIFF
--- a/RISTNet.cpp
+++ b/RISTNet.cpp
@@ -108,6 +108,13 @@ int RISTNetReceiver::receiveData(void *pArg, rist_data_block *pDataBlock) {
     RISTNetReceiver *lWeakSelf = (RISTNetReceiver *) pArg;
     std::lock_guard<std::mutex> lLock(lWeakSelf->mClientListMtx);
 
+    if (lWeakSelf->mClientListReceiver.empty()) {
+        auto lEmptyContext = std::make_shared<NetworkConnection>();
+        lEmptyContext->mObject.reset();
+        auto retVal = lWeakSelf->networkDataCallback((const uint8_t *) pDataBlock->payload, pDataBlock->payload_len, lEmptyContext, pDataBlock->peer, pDataBlock->flow_id);
+        rist_receiver_data_block_free2(&pDataBlock);
+        return retVal;
+    }
     auto netObj = lWeakSelf->mClientListReceiver.find(pDataBlock->peer);
     if (netObj != lWeakSelf->mClientListReceiver.end()) {
         auto netCon = netObj->second;


### PR DESCRIPTION
Caller mode does not work on receiver because the receive callback function searches for a connected clients lists that is only updated in listener mode when a connection is accepted.

This fix takes into account the case when the list is empty.