### PR TITLE
Fix segfault on rist destroy

### DIFF
--- a/RISTNet.h
+++ b/RISTNet.h
@@ -119,9 +119,9 @@ public:
     std::string mCNAME;
     int mSessionTimeout = 5000;
     int mKeepAliveInterval = 10000;
-    int mMaxjitter = 0;
+    int mMaxJitter = 0;
 
-  };
+  } mRistReceiverSettings;
 
   /// Constructor
   RISTNetReceiver();
@@ -364,7 +364,7 @@ public:
     uint32_t mSessionTimeout = 5000;
     uint32_t mKeepAliveInterval = 10000;
     int mMaxJitter = 0;
-   };
+   } mRistSenderSettings;
 
   /// Constructor
   RISTNetSender();


### PR DESCRIPTION
The problem was that I was creating `RISTNetReceiverSettings/RISTNetSenderSettings` structure in the scope of the try{} block on `start()`, in `RistReceiver/RistSender`.

When `rist_destroy` was called, and librist wanted to log something, the `logSettings` pointer was already invalid since the scope was no longer on the try{} block.

The solution was to create a class member for the settings structure and copy all the fields from the structure passed on the `initReceiver()/initSender()` functions.

I also tried to make the structure a class member of `RistReceiver/RistSender` (on swxtch-protocol) but the problem persisted unless I manually called RISTNet's `destroyReceiver()/destroySender()` at the end of `start()`, which means `rist_destroy` was called before the destructors, but this seemed like a partial solution, and I wanted to rely on the destructors to clean everything, not having to manually call the destroy functions.